### PR TITLE
Updated meeting link

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -53,7 +53,7 @@ function Index(props) {
                 <h2 className="header-2">Community Meetings</h2>
                 <div className="pb-4">
                     <p>
-                        Grin Community Council is gathered every 1st and 3rd Tuesday of the month at 6:30pm UTC with a predefined agenda in <a href="https://keybase.io/team/grincoin">Keybase#general channel</a>. Everyone is free to offer agenda topics before the meetings, join the meetings and express their opinions and ideas in a friendly and respectful environment. Previous meetings notes can be found <a href="https://github.com/grincc/agenda/tree/main/notes">here</a>. You can follow next meetings agenda in community council agenda <a href="https://github.com/grincc/agenda/issues">repo</a>.
+                        Grin Community Council is gathered every 1st and 3rd Tuesday of the month at 6:30pm UTC with a predefined agenda on <a href="https://t.me/Grin_Governance">Telegram</a>. Everyone is free to offer agenda topics before the meetings, join the meetings and express their opinions and ideas in a friendly and respectful environment. Previous meetings notes can be found <a href="https://github.com/grincc/agenda/tree/main/notes">here</a>. You can follow next meetings agenda in community council agenda <a href="https://github.com/grincc/agenda/issues">repo</a>.
                     </p>
                 </div>
 

--- a/pages/meetings/index.js
+++ b/pages/meetings/index.js
@@ -473,7 +473,7 @@ function Index(props) {
 
                 <div className="flex flex-col text-center w-full mb-20">
                     <h1 className="header-1">Grin Community Meetings </h1>
-                    <p className="lg:w-2/3 mx-auto leading-relaxed text-base">Grin Community meetings are held biweekly on the first and third weeks of the month at 6:30pm UTC.
+                    <p className="lg:w-2/3 mx-auto leading-relaxed text-base">Grin Community meetings are held biweekly on the first and third weeks of the month at 6:30pm UTC on <a href="https://t.me/Grin_Governance">Telegram</a>.
                     Agenda for meetings are publicly open at <a href="https://github.com/grincc/agenda/issues">grincc/agenda</a> repo.
                     </p>
                     <h2 className="mt-4 py-2 px-8 text-sm bg-primary flex mx-auto w-max text-white rounded-md  tracking-widest font-medium title-font mb-1">


### PR DESCRIPTION
Switched the Keybase link to the new Telegram, also added a link to the Telegram on the meetings page.